### PR TITLE
Fixed mobile, iphone, desktop chatbot help icon & made it Black for convenience

### DIFF
--- a/client/src/components/ChatbotHelp.css
+++ b/client/src/components/ChatbotHelp.css
@@ -192,14 +192,15 @@
     }
   }
 
-  @media (min-width:350px){
+  /* above 380px we translate it by 85px. Removed media queries entirely*/
+  @media (min-width: 401px){
+    
     .chatbotHelpContainer svg:nth-of-type(1){
       transform: translate(175px, 0);
     }
   }
 
-  @media (min-width:375px){
-    
+  @media screen and (min-width: 700px){
     .chatbotHelpContainer svg:nth-of-type(1){
       transform: translate(175px, 85px);
     }

--- a/client/src/components/ChatbotHelp.jsx
+++ b/client/src/components/ChatbotHelp.jsx
@@ -74,7 +74,7 @@ const ChatbotHelp = () => {
             height="auto"
             viewBox="0 -960 960 960"
             width="32px"
-            fill="white"
+            fill="black"
             onClick={() => setShowChatbot(true)}
           >
             <path d="M240-400h320v-80H240v80Zm0-120h480v-80H240v80Zm0-120h480v-80H240v80ZM80-80v-720q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240L80-80Zm126-240h594v-480H160v525l46-45Zm-46 0v-480 480Z" />


### PR DESCRIPTION
Fixed responsiveness of chatbot icon on mobile, iphone and desktop
(PS: just tell me which screen sizes don't work.. I tried but I can't get 'em all. Chrome devtools wasn't matching what I saw on my phone, which caused me a bit of trouble. Thanks!)