### PR TITLE
feat: Add clickable links to footer contact info

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -10,9 +10,19 @@ const Footer = () => {
   ];
 
   const contactInfo = [
-    { icon: "/Contacts/Email.svg", text: "support@ratna.in", alt: "Email" },
-    { icon: "/Contacts/Phone.svg", text: "1-800-9625-45274", alt: "Phone" }
-  ];
+  {
+    icon: "/Contacts/Email.svg",
+    text: "support@ratna.in",
+    alt: "Email",
+    link: "mailto:support@ratna.in", // Mailto link for email
+  },
+  {
+    icon: "/Contacts/Phone.svg",
+    text: "1-800-9625-45274",
+    alt: "Phone",
+    link: "tel:1800962545274", // Tel link for phone number
+  },
+];
 
   return (
     <footer className="bg-gray-50 mt-20">
@@ -54,17 +64,20 @@ const Footer = () => {
             <div className="space-y-4">
               {contactInfo.map((contact) => (
                 <div key={contact.alt} className="flex items-center space-x-3">
-                  <div className="p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors">
-                    <img 
-                      src={contact.icon}
-                      className="h-5 w-5"
-                      alt={contact.alt}
-                    />
-                  </div>
-                  <span className="text-gray-600 hover:text-gray-900 transition-colors">
-                    {contact.text}
-                  </span>
+                <div className="p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors">
+                  <img 
+                    src={contact.icon}
+                    className="h-5 w-5"
+                    alt={contact.alt}
+                  />
                 </div>
+                <a
+                  href={contact.link}
+                  className="text-gray-600 hover:text-gray-900 transition-colors"
+                >
+                  {contact.text}
+                </a>
+              </div>              
               ))}
               
               {/* Location Map */}


### PR DESCRIPTION
This pull request adds functionality to make the footer contact information clickable. Users can now directly interact with the email and phone links in the footer section for better usability.

### Changes Implemented
- Added `mailto` link for the email address.
- Added `tel` link for the phone number.

### Testing
- Verified the email link opens the default email client.
- Verified the phone link prompts a call dialog on supported devices.

## Screenshots 

### Before Changes
The contact info in the footer was plain text, and users could not interact with the email or phone number.
<img width="1440" alt="Screenshot 2024-11-23 at 2 29 52 PM" src="https://github.com/user-attachments/assets/15698605-58a2-4ec2-af4c-f14d93e8833a">


### After Changes
The contact info in the footer is now clickable:
- Clicking the email link opens the default email client.
- Clicking the phone number prompts a call dialog on supported devices.
<img width="1440" alt="Screenshot 2024-11-23 at 2 27 39 PM" src="https://github.com/user-attachments/assets/528f4b6a-2678-4618-bb97-e3e33b2c2175">



## Checklist
- [✅] Code has been tested locally.
- [✅] All functionality works as expected.