### PR TITLE
Fix: corrected cart quantity button alignment (+ on right, - on left)

### DIFF
--- a/client/src/components/BuyCard.jsx
+++ b/client/src/components/BuyCard.jsx
@@ -52,36 +52,50 @@ function BuyCard({ bogo, mrp, discountPrice, imageUrl, productName, discount, id
             }}>ADD</button>
           </div>
         ))}
-        {count > 0 && (
-          <div className='mr-2 flex gap-2 border rounded-full border-green-500'>
-            <span
-              style={{
-                cursor: 'pointer',
-                marginTop: '1px',
-                userSelect: 'none',
-                paddingLeft:"8px",
-                
-              }} onClick={() => {
-                if (count >= 1 && count < 10)
-                  setCount(count + 1);
-                addToCart({ id, productName, discountPrice, imageUrl, count: count + 1 });
-              }}>+</span>
-            <div><input type="text" className=' w-8 bg-green-500 text-white  text-center select-none h-full' value={count} /></div>
-            <span
-              style={{
-                cursor: 'pointer',
-                marginTop: '1px',
-                userSelect: 'none',
-                paddingRight:"8px",
-              }}
-              onClick={() => {
-                if (count >= 1) {
-                  setCount(count - 1);
-                  removeFromCart({ id });
-                }
-              }}> - </span>
-          </div>
-        )}
+       {count > 0 && (
+  <div className='mr-2 flex gap-2 border rounded-full border-green-500 items-center'>
+    {/* Decrement button (-) */}
+    <span
+      style={{
+        cursor: 'pointer',
+        userSelect: 'none',
+        paddingLeft: "8px",
+      }}
+      onClick={() => {
+        if (count >= 1) {
+          setCount(count - 1);
+          removeFromCart({ id });
+        }
+      }}
+    >-</span>
+
+    {/* Count display */}
+    <div>
+      <input 
+        type="text" 
+        className='w-8 bg-green-500 text-white text-center select-none h-full rounded-full' 
+        value={count} 
+        readOnly
+      />
+    </div>
+
+    {/* Increment button (+) */}
+    <span
+      style={{
+        cursor: 'pointer',
+        userSelect: 'none',
+        paddingRight: "8px",
+      }}
+      onClick={() => {
+        if (count >= 1 && count < 10) {
+          setCount(count + 1);
+          addToCart({ id, productName, discountPrice, imageUrl, count: count + 1 });
+        }
+      }}
+    >+</span>
+  </div>
+)}
+
       </div>
       <div className='absolute' style={{
         top: '0',


### PR DESCRIPTION
📌 Issue

After adding an item to the cart, the quantity adjustment buttons were misaligned:

The + button (increase quantity) was on the left.

The - button (decrease quantity) was on the right.

This caused confusion for users since the expected convention is - | count | +.

🔧 Fix Implemented

Reordered the buttons so that:

- is on the left

Quantity in the middle

+ on the right

Added items-center to ensure proper vertical alignment.

Made the quantity input field readOnly to prevent manual edits.

✅ Result

The cart counter now behaves in a familiar and user-friendly way:

- [count] +