### PR TITLE
Allow Saving and Managing Multiple Delivery Locations

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/poppins": "^5.0.12",
         "@hookform/resolvers": "^3.9.0",
         "@material-tailwind/react": "^2.1.9",
-        "@mui/icons-material": "^5.15.10",
+        "@mui/icons-material": "^5.18.0",
         "@mui/material": "^5.15.15",
         "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "@paypal/react-paypal-js": "^8.1.4",
@@ -2038,9 +2038,10 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.15.10",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.10.tgz",
-      "integrity": "sha512-9cF8oUHZKo9oQ7EQ3pxPELaZuZVmphskU4OI6NiJNDVN7zcuvrEsuWjYo1Zh4fLiC39Nrvm30h/B51rcUjvSGA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
+      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -2053,8 +2054,8 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "@fontsource/poppins": "^5.0.12",
     "@hookform/resolvers": "^3.9.0",
     "@material-tailwind/react": "^2.1.9",
-    "@mui/icons-material": "^5.15.10",
+    "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.15.15",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@paypal/react-paypal-js": "^8.1.4",

--- a/client/src/components/AddressBookDialog.jsx
+++ b/client/src/components/AddressBookDialog.jsx
@@ -1,0 +1,71 @@
+import React, { useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+const AddressBookDialog = ({ open, onClose, onSelect }) => {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const addresses = useMemo(() => {
+    try {
+      return JSON.parse(localStorage.getItem('savedAddresses') || '[]');
+    } catch (_) {
+      return [];
+    }
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>Choose a delivery location</DialogTitle>
+      <DialogContent>
+        {addresses.length === 0 ? (
+          <p className="text-sm">No saved locations yet. Choose a pincode and area first.</p>
+        ) : (
+          <div className="flex flex-col gap-2 mt-2">
+            {addresses.map((addr, idx) => (
+              <button
+                key={`${addr.area}-${addr.pincode}-${idx}`}
+                onClick={() => setSelectedIndex(idx)}
+                className={`text-left border rounded p-2 ${selectedIndex === idx ? 'border-blue-600' : 'border-gray-300'}`}
+              >
+                <div className="font-medium">{addr.area}</div>
+                <div className="text-sm text-gray-600">{addr.pincode} · {addr.label || 'Other'}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={() => {
+            onClose();
+            onSelect?.({ addNew: true });
+          }}
+        >
+          Add New Location
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            if (selectedIndex >= 0 && addresses[selectedIndex]) {
+              const chosen = addresses[selectedIndex];
+              localStorage.setItem('userArea', chosen.area);
+              localStorage.setItem('userPincode', chosen.pincode);
+              onSelect?.(chosen);
+            }
+            onClose();
+          }}
+          disabled={addresses.length === 0 || selectedIndex < 0}
+        >
+          Use this location
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AddressBookDialog;
+
+

--- a/client/src/components/AddressBookDialog.jsx
+++ b/client/src/components/AddressBookDialog.jsx
@@ -16,7 +16,21 @@ const AddressBookDialog = ({ open, onClose, onSelect }) => {
   }, [open]);
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth={false}
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          position: 'absolute',
+          top: 16,
+          left: 16,
+          m: 0,
+          transform: 'none'
+        }
+      }}
+    >
       <DialogTitle>Choose a delivery location</DialogTitle>
       <DialogContent>
         {addresses.length === 0 ? (

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -22,6 +22,7 @@ import { useCart } from "../actions/CartControl";
 import SimpleDialog from "./SimpleDialog";
 import SimpleDialog2 from "./SimpleDialog2";
 import SimpleDialog3 from "./SimpleDialog3";
+import AddressBookDialog from "./AddressBookDialog";
 import axios from "axios";
 
 const Navbar = () => {
@@ -94,6 +95,7 @@ const Navbar = () => {
   );
   const [open2, setOpen2] = useState(false);
   const [open3, setOpen3] = useState(false);
+  const [openAddressBook, setOpenAddressBook] = useState(false);
 
   const handleClickOpen2 = () => {
     setOpen2(true);
@@ -108,6 +110,12 @@ const Navbar = () => {
   };
 
   const handleClickOpen = () => {
+    const hasSaved = !!localStorage.getItem("savedAddresses");
+    const hasSelection = localStorage.getItem("userArea") && localStorage.getItem("userPincode");
+    if (hasSaved || hasSelection) {
+      setOpenAddressBook(true);
+      return;
+    }
     setOpen(true);
     handleClickOpen2();
   };
@@ -329,6 +337,17 @@ const Navbar = () => {
         open={open3}
         onClose={handleClose3}
         setIsLogin={setIsLogin}
+      />
+      <AddressBookDialog
+        open={openAddressBook}
+        onClose={() => setOpenAddressBook(false)}
+        onSelect={(sel) => {
+          setOpenAddressBook(false);
+          if (sel && sel.addNew) {
+            setOpen(true);
+            handleClickOpen2();
+          }
+        }}
       />
     </div>
   );

--- a/client/src/components/SimpleDialog.jsx
+++ b/client/src/components/SimpleDialog.jsx
@@ -121,6 +121,20 @@ function SimpleDialog(props) {
                 onSubmit={(e) => {
                   e.preventDefault();
                   localStorage.setItem('userPincode', pincode);
+                  try {
+                    const area = localStorage.getItem('userArea');
+                    if (area && pincode && pincode.length === 6) {
+                      const existing = JSON.parse(localStorage.getItem('savedAddresses') || '[]');
+                      let label = (window.prompt('Label this location (Home, Work, Other):', 'Home') || '').trim();
+                      if (!['Home','Work','Other'].includes(label)) {
+                        label = 'Other';
+                      }
+                      const newEntry = { area, pincode, label };
+                      const exists = existing.some((a) => a.area === newEntry.area && a.pincode === newEntry.pincode);
+                      const updated = exists ? existing : [...existing, newEntry];
+                      localStorage.setItem('savedAddresses', JSON.stringify(updated));
+                    }
+                  } catch (_) {}
                   setPincode('');
                   handleClose();
                 }}
@@ -147,6 +161,17 @@ function SimpleDialog(props) {
                         onClick={(e) => {
                           localStorage.setItem('userArea', suggestion);
                           localStorage.setItem('userPincode', pincode);
+                          try {
+                            const existing = JSON.parse(localStorage.getItem('savedAddresses') || '[]');
+                            let label = (window.prompt('Label this location (Home, Work, Other):', 'Home') || '').trim();
+                            if (!['Home','Work','Other'].includes(label)) {
+                              label = 'Other';
+                            }
+                            const newEntry = { area: suggestion, pincode, label };
+                            const exists = existing.some((a) => a.area === newEntry.area && a.pincode === newEntry.pincode);
+                            const updated = exists ? existing : [...existing, newEntry];
+                            localStorage.setItem('savedAddresses', JSON.stringify(updated));
+                          } catch (_) {}
                           setSuggestions([]);
                         }}
                       >


### PR DESCRIPTION
Fixes #210 
Previous Behavior:
Every time I select the Delivery option, the app asks me to enter my location again, even if I’ve already provided it before.

 Enhanced Changes:
Add a feature that allows users to save multiple delivery locations (e.g., Home, Work, Other). This way, users can quickly select from their saved addresses instead of re-entering the location each time.